### PR TITLE
Release UE Flutter SDK version 5.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.0.3
+* Minore Bug Fixes
+
 # 5.0.2
 * Fixed compatibility issue of Dart SDK with client apps
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.userexperior:userexperior-android:7.3.5'
+        implementation 'com.userexperior:userexperior-android:7.3.7'
 
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'

--- a/lib/src/ue_plugin.dart
+++ b/lib/src/ue_plugin.dart
@@ -4,7 +4,7 @@ import 'internal/user_experior_platform_interface.dart';
 
 class UserExperior {
   static const fw = "fr";
-  static const sv = "5.0.2"; // SDK/Plugin version
+  static const sv = "5.0.3"; // SDK/Plugin version
 
   static final UserExperior _instance = UserExperior();
   /// The default instance of [UserExperior] to use.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: user_experior
 description: "Understand and fix user experience issues."
 
-version: 5.0.2
+version: 5.0.3
 
 homepage: https://www.userexperior.com/
 


### PR DESCRIPTION
# Description

What's new in this release?

- There is a change in the Android platform only, which is recycling bitmap below Android 14, i.e. API level 34 only, as it's taken care of in the later versions, so updated the UE Android SDK version to 7.3.7

# Link(s)

[ISS-124869](https://app.devrev.ai/devrev/works/ISS-124869)