### PR TITLE
Release UE Flutter SDK version 5.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.0.4
+* Minore Bug Fixes
+
 # 5.0.3
 * Minore Bug Fixes
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,7 +52,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.userexperior:userexperior-android:7.3.7'
+        implementation 'com.userexperior:userexperior-android:7.3.8'
 
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.0.0'

--- a/lib/src/ue_plugin.dart
+++ b/lib/src/ue_plugin.dart
@@ -4,7 +4,7 @@ import 'internal/user_experior_platform_interface.dart';
 
 class UserExperior {
   static const fw = "fr";
-  static const sv = "5.0.3"; // SDK/Plugin version
+  static const sv = "5.0.4"; // SDK/Plugin version
 
   static final UserExperior _instance = UserExperior();
   /// The default instance of [UserExperior] to use.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: user_experior
 description: "Understand and fix user experience issues."
 
-version: 5.0.3
+version: 5.0.4
 
 homepage: https://www.userexperior.com/
 


### PR DESCRIPTION
# Description

### What's new in this release?

- Debouncer Implementation to fix Mirae Asset ANRs
- Fixed setUserProperties(...) to append all the properties if it is called multiple times, raised by IndusInd
- The getActiveNetworkInfo() call was deprecated so it was replaced with the latest method, also removed usage of TelephonyManager as it required explicit READ_PHONE_STATE permission to avoid any crashes - Clients: ABCD, Bajaj Finserv, now for Network Type, we won't be detecting 2G/3G/4G/5G due to Google Restrictions and dangerous permissions required, we will only show either Cellular or WiFi
- Nuvama was facing crashes on Android 13 due to bad bitmap handling. Handled the recycling of bitmap based on Android version

# Link(s)

- [ISS-129248](https://app.devrev.ai/devrev/works/ISS-129248)